### PR TITLE
修复在低版本系统上的const兼容问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ export default function (App) {
     // 生命周期函数--监听页面加载
     onLoad(query) {
       //页面加载的时候
-      const app = new Vue(App);
+      var app = new Vue(App);
       // 挂载Vue对象到page上
       this.$vm = app;
       var rootVueVM = app.$root;


### PR DESCRIPTION
mpvue 项目下webpack默认不构建node_modules里的文件，低版本系统（例如ios8，ios9）会报错： Const declarations are not supported in strict mode